### PR TITLE
Correct schema $id

### DIFF
--- a/specifications/pattern_specification.json
+++ b/specifications/pattern_specification.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://github.com/ansible/pattern-service/blob/main/specifications/pattern_specification.json",
+    "$id": "https://raw.githubusercontent.com/ansible/pattern-service/refs/heads/main/specifications/pattern_specification.json",
     "title": "Ansible Pattern Schema",
     "description": "A schema for validating Ansible pattern definitions",
     "type": "object",


### PR DESCRIPTION
Schema $id must point to a JSON fine that can be downloaded. Previous one was a github website link that cannot be used. This is critical as JSON schema tools will try to update the schema using its $id.

Example of correctly configured `$id`: https://github.com/ansible/ansible-lint/blob/main/src/ansiblelint/schemas/galaxy.json#L743
