### PR TITLE
add custom key for ansible-lint to validate pattern schemas

### DIFF
--- a/specifications/pattern-schema/pattern-schema-dev.json
+++ b/specifications/pattern-schema/pattern-schema-dev.json
@@ -4,7 +4,9 @@
     "title": "Ansible Pattern Schema",
     "description": "A schema for validating Ansible pattern definitions",
     "type": "object",
-    "x-ansible-lint": ["patterns/*/meta/pattern.json"],
+    "x-ansible-lint": [
+        "patterns/*/meta/pattern.json"
+    ],
     "required": [
         "schema_version",
         "name",

--- a/specifications/pattern-schema/pattern-schema-dev.json
+++ b/specifications/pattern-schema/pattern-schema-dev.json
@@ -4,6 +4,7 @@
     "title": "Ansible Pattern Schema",
     "description": "A schema for validating Ansible pattern definitions",
     "type": "object",
+    "x-ansible-lint": ["patterns/*/meta/pattern.json"],
     "required": [
         "schema_version",
         "name",


### PR DESCRIPTION
[ansible-lint ](https://github.com/ansible/ansible-lint/pull/4690) has extended schemas tests by looking for an `x-ansible-lint` key. This PR updates pattern schema definition to reflect that change.

Refer to https://issues.redhat.com/browse/AAP-51522