### PR TITLE
SonarCloud Oktokit version fix.

### DIFF
--- a/.github/workflows/sonar_checks.yml
+++ b/.github/workflows/sonar_checks.yml
@@ -43,7 +43,7 @@ jobs:
           echo "$PR_NUMBER=$(cat pr-number.txt)" >> $GITHUB_ENV
 
       - name: Get PR info
-        uses: octokit/request-action@v2
+        uses: octokit/request-action@v2.x
         id: pr_info
         with:
           route: GET /repos/{repo}/pulls/{number}


### PR DESCRIPTION
SonarCloud workflow check was failing with:

`Error: Unable to resolve action , unable to find version `v2`. `

Updating oktokit/request-action version to v2.x as per aap-dev's configuration and oktokit documented examples here: https://github.com/octokit/request-action.


