### PR TITLE
SonarQube Scan Location Update

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -20,7 +20,7 @@ sonar.projectName=pattern-service
 sonar.sources=.
 
 # Test directories
-sonar.tests=core/tests,pattern_service/tests
+sonar.tests=core/tests
 
 # Test file patterns
 sonar.test.inclusions=**/test_*.py


### PR DESCRIPTION
removed reference to pattern_service/tests for CI as it does not exist and is causing errors in SonarQube testing.
